### PR TITLE
Update Ventura documentation

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -150,7 +150,7 @@ Adding write permissions on mapping models fixes this issue. In a project using 
 
 ```
 # Get SRGUserData checkout path.
-SRG_USER_DATA="${DERIVED_DATA_DIR}/SourcePackages/checkouts/srguserdata-apple"
+SRG_USER_DATA=$(find "$DERIVED_DATA_DIR" -path "*/SourcePackages/checkouts/srguserdata-apple" -type d)
 
 # Apply SRGUserData script.
 sh "$SRG_USER_DATA/Scripts/coredata-compilation-fix.sh" "$SRG_USER_DATA"


### PR DESCRIPTION
### Motivation and Context

Following #6, the proposed script in getting started was not correct.

### Description

- For Mac OS Ventura known issue, the proposed script in documentation updated.
- The new script version takes care of the unique subfolder of Xcode's derived data location.

### Checklist

- [x] The branch has to be rebased onto the `develop` branch for whole tests.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).