### PR TITLE
Disable flaky tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+# Description
+
+> Why is this change required? What problem does it solve?
+
+# Changes made
+
+> Please list the specific changes made in this pull request.
+
+# Checklist
+
+- The branch should be rebased onto the `develop` branch for whole tests.
+- [ ] APIs have been properly documented (if relevant).
+- [ ] The documentation has been updated (if relevant).
+- [ ] New unit tests have been written (if relevant).
+- [ ] All `UserObjectTestCase` tests has passed successfully locally, included flacky disabled ones.
+- [ ] The demo has been updated (if relevant).
+- [ ] Issues are linked to the PR, if any.

--- a/Tests/SRGUserData-tests.xcodeproj/xcshareddata/xcschemes/SRGUserData-tests.xcscheme
+++ b/Tests/SRGUserData-tests.xcodeproj/xcshareddata/xcschemes/SRGUserData-tests.xcscheme
@@ -27,6 +27,24 @@
                <Test
                   Identifier = "DataStoreTestCase/testGlobalCancellation">
                </Test>
+               <Test
+                  Identifier = "UserObjectTestCase/testDiscardForLoggedInUser">
+               </Test>
+               <Test
+                  Identifier = "UserObjectTestCase/testDiscardForLoggedOutUser">
+               </Test>
+               <Test
+                  Identifier = "UserObjectTestCase/testObjectsMatchingPredicate">
+               </Test>
+               <Test
+                  Identifier = "UserObjectTestCase/testSynchronizeDeletedEntryExistingLocally">
+               </Test>
+               <Test
+                  Identifier = "UserObjectTestCase/testSynchronizeDeletedEntryMoreRecentLocally">
+               </Test>
+               <Test
+                  Identifier = "UserObjectTestCase/testSynchronizeMoreRecentDirtyLocalEntry">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Tests/SRGUserDataTests/UserObjectTestCase.m
+++ b/Tests/SRGUserDataTests/UserObjectTestCase.m
@@ -39,6 +39,7 @@
 
 #pragma mark Tests
 
+#warning "This flaky test has been disabled. See issue #7"
 - (void)testObjectsMatchingPredicate
 {
     NSPersistentContainer *persistentContainer = [self persistentContainerFromPackage:@"UserData_DB_loggedIn"];
@@ -143,6 +144,7 @@
     }];
 }
 
+#warning "This flaky test has been disabled. See issue #7"
 - (void)testSynchronizeMoreRecentDirtyLocalEntry
 {
     NSPersistentContainer *persistentContainer = [self persistentContainerFromPackage:@"UserData_DB_loggedIn"];
@@ -158,6 +160,7 @@
     }];
 }
 
+#warning "This flaky test has been disabled. See issue #7"  
 - (void)testSynchronizeDeletedEntryExistingLocally
 {
     NSPersistentContainer *persistentContainer = [self persistentContainerFromPackage:@"UserData_DB_loggedIn"];
@@ -173,6 +176,7 @@
     }];
 }
 
+#warning "This flaky test has been disabled. See issue #7"
 - (void)testSynchronizeDeletedEntryMoreRecentLocally
 {
     NSPersistentContainer *persistentContainer = [self persistentContainerFromPackage:@"UserData_DB_loggedIn"];
@@ -189,6 +193,7 @@
     }];
 }
 
+#warning "This flaky test has been disabled. See issue #7"
 - (void)testDiscardForLoggedOutUser
 {
     NSPersistentContainer *persistentContainer = [self persistentContainerFromPackage:@"UserData_DB_loggedOut"];
@@ -215,6 +220,7 @@
     }];
 }
 
+#warning "This flaky test has been disabled. See issue #7"
 - (void)testDiscardForLoggedInUser
 {
     NSPersistentContainer *persistentContainer = [self persistentContainerFromPackage:@"UserData_DB_loggedIn"];


### PR DESCRIPTION
# Description

Following investigation #7, the CI for now can't passed all `UserObjectTestCase ` tests.
Maintenance strategy is to run it locally.

# Changes made

- Disable flaky tests listed in #7.
- Add Github Pull request template and mentioned to run tests locally.

# Checklist

- The branch should be rebased onto the `develop` branch for whole tests.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] All `UserObjectTestCase` tests has passed successfully locally, included flacky disabled ones.
- [x] The demo has been updated (if relevant).
- [x] Issues are linked to the PR, if any.